### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/meta/Thinktecture.NETStandard.Library.Abstractions/Thinktecture.NETStandard.Library.Abstractions.csproj
+++ b/meta/Thinktecture.NETStandard.Library.Abstractions/Thinktecture.NETStandard.Library.Abstractions.csproj
@@ -6,7 +6,16 @@
 		<DebugSymbols>false</DebugSymbols>
 		<DebugType>None</DebugType>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net461' ">
 		<ProjectReference Include="..\..\src\Thinktecture.IO.Abstractions\Thinktecture.IO.Abstractions.csproj" />
 		<ProjectReference Include="..\..\src\Thinktecture.Net.Primitives.Abstractions\Thinktecture.Net.Primitives.Abstractions.csproj" />

--- a/src/Thinktecture.Abstractions/Thinktecture.Abstractions.csproj
+++ b/src/Thinktecture.Abstractions/Thinktecture.Abstractions.csproj
@@ -3,5 +3,13 @@
     <Description>Provides types used by all Thinktecture.*.Abstractions projects.</Description>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net45;net46</TargetFrameworks>
     <PackageTags>abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/src/Thinktecture.Console.Abstractions/Thinktecture.Console.Abstractions.csproj
+++ b/src/Thinktecture.Console.Abstractions/Thinktecture.Console.Abstractions.csproj
@@ -3,7 +3,16 @@
 		<Description>Provides interfaces for types in System.Console: Console.</Description>
 		<TargetFrameworks>netstandard1.3;netstandard2.0;net46</TargetFrameworks>
 		<PackageTags>console;abstraction</PackageTags>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 	  <ProjectReference Include="..\Thinktecture.IO.Abstractions\Thinktecture.IO.Abstractions.csproj" />
 	  <ProjectReference Include="..\Thinktecture.Text.Encoding.Abstractions\Thinktecture.Text.Encoding.Abstractions.csproj" />

--- a/src/Thinktecture.IO.Abstractions/Thinktecture.IO.Abstractions.csproj
+++ b/src/Thinktecture.IO.Abstractions/Thinktecture.IO.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.IO: Stream, MemoryStream, BinaryReader, BinaryWriter, StreamReader, StreamWriter, StringReader, StringWriter, TextReader, TextWriter.</Description>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;netstandard2.0;netcoreapp2.2;net45;net462</TargetFrameworks>
     <PackageTags>io;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Runtime.Abstractions\Thinktecture.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\Thinktecture.Text.Encoding.Abstractions\Thinktecture.Text.Encoding.Abstractions.csproj" />

--- a/src/Thinktecture.IO.FileSystem.Abstractions/Thinktecture.IO.FileSystem.Abstractions.csproj
+++ b/src/Thinktecture.IO.FileSystem.Abstractions/Thinktecture.IO.FileSystem.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.IO.FileSystem: Directory, File, FileSystemInfo, DirectoryInfo, FileInfo, FileStream, SafeFileHandle.</Description>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.2;net46</TargetFrameworks>
     <PackageTags>io;filesystem;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.IO.Abstractions\Thinktecture.IO.Abstractions.csproj" />
     <ProjectReference Include="..\Thinktecture.Text.Encoding.Abstractions\Thinktecture.Text.Encoding.Abstractions.csproj" />

--- a/src/Thinktecture.IO.FileSystem.Watcher.Abstractions/Thinktecture.IO.FileSystem.Watcher.Abstractions.csproj
+++ b/src/Thinktecture.IO.FileSystem.Watcher.Abstractions/Thinktecture.IO.FileSystem.Watcher.Abstractions.csproj
@@ -4,7 +4,15 @@
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46</TargetFrameworks>
     <PackageTags>filesystemwatcher;abstraction</PackageTags>
     <NoWarn>RCS1159</NoWarn>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Abstractions\Thinktecture.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Thinktecture.IO.Pipes.Abstractions/Thinktecture.IO.Pipes.Abstractions.csproj
+++ b/src/Thinktecture.IO.Pipes.Abstractions/Thinktecture.IO.Pipes.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.IO.Pipes: NamedPipeServerStream, NamedPipeClientStream, PipeStream.</Description>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46</TargetFrameworks>
     <PackageTags>io;pipes;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.IO.Abstractions\Thinktecture.IO.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Thinktecture.Net.Http.Abstractions/Thinktecture.Net.Http.Abstractions.csproj
+++ b/src/Thinktecture.Net.Http.Abstractions/Thinktecture.Net.Http.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.Net.Http: HttpClient, HttpContent, HttpRequestMessage, HttpResponseMessage, HttpHeaders, DelegatingHandler, HttpClientHandler, HttpMessageHandler, HttpMessageInvoker, MessageProcessingHandler, MultipartContent, MultipartFormDataContent, HttpContentHeaders, HttpRequestHeaders, HttpResponseHeaders.</Description>
     <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard1.6;netstandard2.0;net45;net46</TargetFrameworks>
     <PackageTags>http;net;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.IO.Abstractions\Thinktecture.IO.Abstractions.csproj" />
     <ProjectReference Include="..\Thinktecture.Net.Primitives.Abstractions\Thinktecture.Net.Primitives.Abstractions.csproj" />

--- a/src/Thinktecture.Net.NetworkInformation.Abstractions/Thinktecture.Net.NetworkInformation.Abstractions.csproj
+++ b/src/Thinktecture.Net.NetworkInformation.Abstractions/Thinktecture.Net.NetworkInformation.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.Net.NetworkInformation: NetworkInterface, PhysicalAddress, IPAddressInformation, IPAddressInformationCollection, IPInterfaceProperties, IPInterfaceStatistics, IPv4InterfaceProperties, IPv6InterfaceProperties, UnicastIPAddressInformation, UnicastIPAddressInformationCollection, MulticastIPAddressInformation, MulticastIPAddressInformationCollection, GatewayIPAddressInformation, GatewayIPAddressInformationCollection.</Description>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <PackageTags>network;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Net.Primitives.Abstractions\Thinktecture.Net.Primitives.Abstractions.csproj" />
     <ProjectReference Include="..\Thinktecture.Runtime.Abstractions\Thinktecture.Runtime.Abstractions.csproj" />

--- a/src/Thinktecture.Net.Primitives.Abstractions/Thinktecture.Net.Primitives.Abstractions.csproj
+++ b/src/Thinktecture.Net.Primitives.Abstractions/Thinktecture.Net.Primitives.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.Net.Primitives: Cookie, CookieCollection, CookieContainer, NetworkCredential.</Description>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard1.3;netstandard2.0;netcoreapp2.2;net45</TargetFrameworks>
     <PackageTags>net;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Abstractions\Thinktecture.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Thinktecture.Net.Sockets.Abstractions/Thinktecture.Net.Sockets.Abstractions.csproj
+++ b/src/Thinktecture.Net.Sockets.Abstractions/Thinktecture.Net.Sockets.Abstractions.csproj
@@ -4,7 +4,15 @@
     <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.2;net46</TargetFrameworks>
     <PackageTags>sockets;abstraction</PackageTags>
     <NoWarn>RCS1047</NoWarn>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.IO.Abstractions\Thinktecture.IO.Abstractions.csproj" />
     <ProjectReference Include="..\Thinktecture.Net.Primitives.Abstractions\Thinktecture.Net.Primitives.Abstractions.csproj" />

--- a/src/Thinktecture.Runtime.Abstractions/Thinktecture.Runtime.Abstractions.csproj
+++ b/src/Thinktecture.Runtime.Abstractions/Thinktecture.Runtime.Abstractions.csproj
@@ -4,7 +4,15 @@
     <TargetFrameworks>netstandard1.0;netstandard1.2;netstandard1.3;netstandard1.5;netstandard2.0;netcoreapp2.2;net45;net462</TargetFrameworks>
     <PackageTags>runtime;abstraction</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Abstractions\Thinktecture.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Thinktecture.Runtime.Extensions.Abstractions/Thinktecture.Runtime.Extensions.Abstractions.csproj
+++ b/src/Thinktecture.Runtime.Extensions.Abstractions/Thinktecture.Runtime.Extensions.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for type in System.Runtime.Extensions: Path, BitConverter, Convert, Environment, Math, Random, UriBuilder, Stopwatch, WebUtility.</Description>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;netstandard2.0;netcoreapp2.2;netcoreapp2.2;net45;net462</TargetFrameworks>
     <PackageTags>runtime;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Abstractions\Thinktecture.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Thinktecture.Runtime.Handles.Abstractions/Thinktecture.Runtime.Handles.Abstractions.csproj
+++ b/src/Thinktecture.Runtime.Handles.Abstractions/Thinktecture.Runtime.Handles.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.Runtime.Handles: SafeHandle, CriticalHandle, SafeWaitHandle.</Description>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46</TargetFrameworks>
     <PackageTags>handles;abstraction</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Abstractions\Thinktecture.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Thinktecture.Text.Encoding.Abstractions/Thinktecture.Text.Encoding.Abstractions.csproj
+++ b/src/Thinktecture.Text.Encoding.Abstractions/Thinktecture.Text.Encoding.Abstractions.csproj
@@ -4,7 +4,15 @@
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0;netcoreapp2.2;net45</TargetFrameworks>
     <PackageTags>encoding;abstraction</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Thinktecture.Abstractions\Thinktecture.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Thinktecture.Threading.Tasks.Abstractions/Thinktecture.Threading.Tasks.Abstractions.csproj
+++ b/src/Thinktecture.Threading.Tasks.Abstractions/Thinktecture.Threading.Tasks.Abstractions.csproj
@@ -3,7 +3,15 @@
     <Description>Provides interfaces for types in System.Threading.Tasks: Task, Task&lt;T&gt;, TaskFactory, TaskFactory&lt;T&gt;.</Description>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0;netcoreapp2.2;net45</TargetFrameworks>
     <PackageTags>abstraction;threading;task</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
